### PR TITLE
Removed import of patterns module

### DIFF
--- a/autoradio/doc/urls.py
+++ b/autoradio/doc/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import *
 #from django.views.generic.simple import direct_to_template
-from django.conf.urls import patterns
+#from django.conf.urls import patterns
 from django.views.generic import TemplateView
 
 urlpatterns = [


### PR DESCRIPTION
Removed import from patterns module as from Django 1.10 has been removed (deprecated from version 1.8).